### PR TITLE
Account for rgb and rgba colors in quad swap

### DIFF
--- a/r2.js
+++ b/r2.js
@@ -14,7 +14,7 @@ var fs = require('fs')
 
 function quad(v, m) {
   // 1px 2px 3px 4px => 1px 4px 3px 2px
-  if ((m = v.trim().split(/\s+/)) && m.length == 4) {
+  if ((m = v.trim().split(/\s+(?=[^\)]*(?:[\(]|$))/)) && m.length == 4) {
     return [m[0], m[3], m[2], m[1]].join(' ')
   }
   return v

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -25,6 +25,11 @@ sink('border', function(test, ok, before, after, assert) {
     assert.equal(swap('p{border-color:#fff #000;}'), 'p{border-color:#fff #000;}', 'border-color: #fff #000 => border-color: #fff #000')
     assert.equal(swap('p{border-color:#000 #111 #222;}'), 'p{border-color:#000 #111 #222;}', 'border-color: #000 #111 #222 => border-color: #000 #111 #222')
     assert.equal(swap('p{border-color:#000 #111 #222 #333;}'), 'p{border-color:#000 #333 #222 #111;}', 'border-color: #000 #111 #222 #333 => border-color: #000 #333 #222 #111')
+    assert.equal(swap('p{border-color:rgb(0, 0, 0);}'), 'p{border-color:rgb(0, 0, 0);}', 'border-color:rgb(0, 0, 0) => border-color:rgb(0, 0, 0)')
+    assert.equal(swap('p{border-color:rgba(0, 0, 0, 0.15);}'), 'p{border-color:rgba(0, 0, 0, 0.15);}', 'border-color:rgba(0, 0, 0, 0.15) => border-color:rgba(0, 0, 0, 0.15)')
+    assert.equal(swap('p{border-color:rgb(0, 0, 0) rgb(1, 1, 1);}'), 'p{border-color:rgb(0, 0, 0) rgb(1, 1, 1);}', 'border-color:rgb(0, 0, 0) rgb(1, 1, 1) => border-color:rgb(0, 0, 0) rgb(1, 1, 1)')
+    assert.equal(swap('p{border-color:rgb(0, 0, 0) rgb(1, 1, 1) rgb(2, 2, 2);}'), 'p{border-color:rgb(0, 0, 0) rgb(1, 1, 1) rgb(2, 2, 2);}', 'border-color:rgb(0, 0, 0) rgb(1, 1, 1) rgb(2, 2, 2) => border-color:rgb(0, 0, 0) rgb(1, 1, 1) rgb(2, 2, 2)')
+    assert.equal(swap('p{border-color:rgb(0, 0, 0) rgb(1, 1, 1) rgb(2, 2, 2) rgb(3, 3, 3);}'), 'p{border-color:rgb(0, 0, 0) rgb(3, 3, 3) rgb(2, 2, 2) rgb(1, 1, 1);}', 'border-color:rgb(0, 0, 0) rgb(1, 1, 1) rgb(2, 2, 2) rgb(3, 3, 3) => border-color:rgb(0, 0, 0) rgb(3, 3, 3) rgb(2, 2, 2) rgb(1, 1, 1)')
     done()
   })
 


### PR DESCRIPTION
Hey @jbalsas 

I noticed that rgba colors are getting improperly swapped if they have spaces inside the parentheses. So...

`rgba(4, 4, 4, 0.15)` would be converted to `rgba(0, 0.15) 0, 0,`

This pull just updates the regex in charge of splitting the string so that it only matches white space characters that aren't inside of parentheses.
